### PR TITLE
Prevent integer truncation at pixel.price

### DIFF
--- a/contracts/Dixel.sol
+++ b/contracts/Dixel.sol
@@ -111,12 +111,14 @@ contract Dixel is Ownable, ReentrancyGuard, DixelSVGGenerator {
         uint256 totalPrice = 0;
         for (uint256 i = 0; i < params.length; i++) {
             Pixel storage pixel = pixels[params[i].x][params[i].y];
+            uint200 price = pixel.price;
 
             pixel.color = params[i].color;
             pixel.owner = player.id;
-            totalPrice += pixel.price;
+            totalPrice += price;
 
-            pixel.price = uint200(pixel.price + pixel.price * PRICE_INCREASE_RATE / MAX_RATE);
+            pixel.price = uint200(price + price * PRICE_INCREASE_RATE / MAX_RATE);
+            require(pixel.price > price, "MAX_PRICE_REACHED");
         }
 
         // 10% goes to the contributor reward pools


### PR DESCRIPTION
해당 `+` 연산의 우항이 `uint256` 타입이기 때문에 결과값이 `2^200`보다 커질 수 있으며, `uint200`으로의 명시적인 타입 캐스팅은 정수가 truncate될 때 revert를 발생시키지 않기 때문에 1992회 [1] 같은 픽셀이 업데이트되면 해당 pixel을 수정하는데 쓰이는 가격이 확연히 낮아질 수 있습니다.

이를 방지하기 위해 수정된 price가 원래 price보다 같거나 높은지에 대한 검사를 추가합니다.

[1]: `log_1.05(2^200 / GENESIS_PRICE) = 1991...`