### PR TITLE
handled twice burning

### DIFF
--- a/contracts/DixelArt.sol
+++ b/contracts/DixelArt.sol
@@ -91,6 +91,10 @@ contract DixelArt is Context, ERC721, ERC721Enumerable, Ownable, DixelSVGGenerat
 
     function burn(uint256 tokenId) external {
         address msgSender = _msgSender();
+
+        // Check if token has already been burned, distinguishing it from revert due to non existing tokenId
+        require(history[tokenId].burned != true, "ERC721Burnable: token has already been burned");
+
         // This will also check `_exists(tokenId)`
         require(_isApprovedOrOwner(msgSender, tokenId), "ERC721Burnable: caller is not owner nor approved");
 

--- a/test/DixelArt.test.js
+++ b/test/DixelArt.test.js
@@ -1,4 +1,4 @@
-const { ether, BN, constants, expectEvent } = require("@openzeppelin/test-helpers");
+const { ether, BN, constants, expectEvent, expectRevert } = require("@openzeppelin/test-helpers");
 const { MAX_UINT256 } = constants;
 const { expect } = require("chai");
 const fs = require("fs");
@@ -132,6 +132,13 @@ contract("DixelArt", function(accounts) {
 
       it("should leave nextTokenId to the same", async function() {
         expect(await this.nft.nextTokenId()).to.be.bignumber.equal("1");
+      });
+
+      it("should revert with ERC721Burnable: token has already been burned if trying to burning twice", async function() {
+        await expectRevert(
+            this.nft.burn(0, { from: alice }),
+            'ERC721Burnable: token has already been burned'
+        );
       });
     }); // burn
   }); // generate NFT


### PR DESCRIPTION
When a user tries to burn 2 times a token, the second time the error is `ERC721: operator query for nonexistent token`

This PR aims to improve the error message, from `ERC721: operator query for nonexistent token` to `ERC721Burnable: token has already been burned`, because sometimes it's useful to know if the burn went wrong because of a token not found or because the token was already burnt