### PR TITLE
Change color history to be incremental, save ~70% of gas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-yarn.lock
 *.swp
 *.swo
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+yarn.lock
 *.swp
 *.swo
 

--- a/contracts/Dixel.sol
+++ b/contracts/Dixel.sol
@@ -31,12 +31,6 @@ contract Dixel is Ownable, ReentrancyGuard, DixelSVGGenerator {
         uint200 price; // GAS_SAVING
     }
 
-    struct PixelParams {
-        uint8 x;
-        uint8 y;
-        uint24 color;
-    }
-
     struct Player {
         uint32 id;
         uint32 contribution;

--- a/contracts/Dixel.sol
+++ b/contracts/Dixel.sol
@@ -8,6 +8,8 @@ import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "./lib/ColorUtils.sol";
 import "./DixelSVGGenerator.sol";
 import "./DixelArt.sol";
+import "./IPixelParams.sol";
+
 
 /**
 * @title Dixel
@@ -102,7 +104,7 @@ contract Dixel is Ownable, ReentrancyGuard, DixelSVGGenerator {
         return players[wallet];
     }
 
-    function updatePixels(PixelParams[] calldata params, uint256 nextTokenId) external nonReentrant {
+    function updatePixels(IPixelParams.PixelParams[] calldata params, uint256 nextTokenId) external nonReentrant {
         require(params.length > 0 && params.length <= CANVAS_SIZE * CANVAS_SIZE, "INVALID_PIXEL_PARAMS");
         require(nextTokenId == dixelArt.nextTokenId(), "NFT_EDITION_NUMBER_MISMATCHED");
 
@@ -139,7 +141,7 @@ contract Dixel is Ownable, ReentrancyGuard, DixelSVGGenerator {
         (uint96 reward, uint96 reserveForRefund) = _updatePlayerReward(player, totalPrice, updatedPixelCount);
 
         // Mint NFT to the user
-        dixelArt.mint(msgSender, getPixelColors(), updatedPixelCount, reserveForRefund);
+        dixelArt.mint(msgSender, params, updatedPixelCount, reserveForRefund);
 
         emit UpdatePixels(msgSender, updatedPixelCount, uint96(totalPrice), reward);
     }

--- a/contracts/DixelArt.sol
+++ b/contracts/DixelArt.sol
@@ -11,6 +11,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "base64-sol/base64.sol";
 import "./lib/ColorUtils.sol";
 import "./DixelSVGGenerator.sol";
+import "./IPixelParams.sol";
+
 
 /**
  * @dev DixelArt NFT token, including:
@@ -26,12 +28,18 @@ contract DixelArt is Context, ERC721, ERC721Enumerable, Ownable, DixelSVGGenerat
     IERC20 public baseToken;
 
     struct History {
-        uint24[CANVAS_SIZE][CANVAS_SIZE] pixels;
         uint16 updatedPixelCount;
         uint96 reserveForRefund;
         bool burned;
     }
     History[] public history;
+
+    struct PixelSnapshot {
+        uint256 tokenId;
+        uint24 color;
+    }
+    mapping(uint256 => mapping(uint256 => PixelSnapshot[])) public colorsHistory; // [x,y] -> snapshot
+
 
     event Burn(address player, uint256 tokenId, uint96 refundAmount);
 
@@ -40,8 +48,38 @@ contract DixelArt is Context, ERC721, ERC721Enumerable, Ownable, DixelSVGGenerat
         baseToken = IERC20(baseTokenAddress);
     }
 
-    function getPixelsFor(uint256 tokenId) public view returns (uint24[CANVAS_SIZE][CANVAS_SIZE] memory) {
-        return history[tokenId].pixels;
+    function getPixelsFor(uint256 tokenId) public view returns (uint24[CANVAS_SIZE][CANVAS_SIZE] memory pixelColors) {
+        for (uint256 x = 0; x < CANVAS_SIZE; x++) {
+            for (uint256 y = 0; y < CANVAS_SIZE; y++) {
+                pixelColors[x][y] = getPixelAt(tokenId, x, y);
+            }
+        }
+    }
+
+    // This function is copied almost verbatim from OZ's Arrays.sol.
+    function getPixelAt(uint256 tokenId, uint256 x, uint256 y) public view returns (uint24) {
+        PixelSnapshot[] storage array = colorsHistory[x][y];
+        if (array.length == 0) return 0;
+        if (tokenId == array[array.length-1].tokenId) return array[array.length-1].color;
+        if (tokenId > array[array.length-1].tokenId) return 0; // same behavior as previous implementation
+    
+        uint256 high = array.length;
+        uint256 low = 0;
+
+        while (low < high) {
+            uint256 mid = (low & high) + (low ^ high) / 2;
+            if (array[mid].tokenId > tokenId) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        if (low > 0 && array[low-1].tokenId == tokenId) {
+            return array[low-1].color;
+        } else {
+            return array[low].color;
+        }
     }
 
     function generateSVG(uint256 tokenId) external view returns (string memory) {
@@ -78,13 +116,16 @@ contract DixelArt is Context, ERC721, ERC721Enumerable, Ownable, DixelSVGGenerat
         return string(abi.encodePacked("data:application/json;base64,", Base64.encode(bytes(generateJSON(tokenId)))));
     }
 
-    function mint(address to, uint24[CANVAS_SIZE][CANVAS_SIZE] memory pixelColors, uint16 updatedPixelCount, uint96 reserveForRefund) external onlyOwner {
+    function mint(address to, IPixelParams.PixelParams[] calldata params, uint16 updatedPixelCount, uint96 reserveForRefund) external onlyOwner {
         // We cannot just use balanceOf to create the new tokenId because tokens
         // can be burned (destroyed), so we need a separate counter.
         uint256 tokenId = _tokenIdTracker.current();
         _mint(to, tokenId);
 
-        history.push(History(pixelColors, updatedPixelCount, reserveForRefund, false));
+        history.push(History(updatedPixelCount, reserveForRefund, false));
+        for (uint256 i = 0; i < params.length; i++) {
+            colorsHistory[params[i].x][params[i].y].push(PixelSnapshot(tokenId,params[i].color));
+        }
 
         _tokenIdTracker.increment();
     }

--- a/contracts/DixelArt.sol
+++ b/contracts/DixelArt.sol
@@ -60,8 +60,8 @@ contract DixelArt is Context, ERC721, ERC721Enumerable, Ownable, DixelSVGGenerat
     function getPixelAt(uint256 tokenId, uint256 x, uint256 y) public view returns (uint24) {
         PixelSnapshot[] storage array = colorsHistory[x][y];
         if (array.length == 0) return 0;
-        if (tokenId == array[array.length-1].tokenId) return array[array.length-1].color;
-        if (tokenId > array[array.length-1].tokenId) return 0; // same behavior as previous implementation
+        if (tokenId == _tokenIdTracker.current() - 1) return array[array.length-1].color; // if latest edition - just return last color
+        if (tokenId > _tokenIdTracker.current()) return 0; // same behavior as previous implementation
     
         uint256 high = array.length;
         uint256 low = 0;

--- a/contracts/DixelArt.sol
+++ b/contracts/DixelArt.sol
@@ -13,7 +13,6 @@ import "./lib/ColorUtils.sol";
 import "./DixelSVGGenerator.sol";
 import "./IPixelParams.sol";
 
-
 /**
  * @dev DixelArt NFT token, including:
  *
@@ -40,7 +39,6 @@ contract DixelArt is Context, ERC721, ERC721Enumerable, Ownable, DixelSVGGenerat
     }
     mapping(uint256 => mapping(uint256 => PixelSnapshot[])) public colorsHistory; // [x,y] -> snapshot
 
-
     event Burn(address player, uint256 tokenId, uint96 refundAmount);
 
     // solhint-disable-next-line func-visibility
@@ -61,7 +59,7 @@ contract DixelArt is Context, ERC721, ERC721Enumerable, Ownable, DixelSVGGenerat
         PixelSnapshot[] storage array = colorsHistory[x][y];
         if (array.length == 0) return 0;
         if (tokenId == _tokenIdTracker.current() - 1) return array[array.length-1].color; // if latest edition - just return last color
-        if (tokenId > _tokenIdTracker.current()) return 0; // same behavior as previous implementation
+        if (tokenId > _tokenIdTracker.current() - 1) return 0; // same behavior as previous implementation
     
         uint256 low = 0;
         uint256 high = array.length;

--- a/contracts/DixelArt.sol
+++ b/contracts/DixelArt.sol
@@ -56,18 +56,18 @@ contract DixelArt is Context, ERC721, ERC721Enumerable, Ownable, DixelSVGGenerat
         }
     }
 
-    // This function is copied almost verbatim from OZ's Arrays.sol.
+    // This function is based upon OZ's Arrays.sol.
     function getPixelAt(uint256 tokenId, uint256 x, uint256 y) public view returns (uint24) {
         PixelSnapshot[] storage array = colorsHistory[x][y];
         if (array.length == 0) return 0;
         if (tokenId == _tokenIdTracker.current() - 1) return array[array.length-1].color; // if latest edition - just return last color
         if (tokenId > _tokenIdTracker.current()) return 0; // same behavior as previous implementation
     
-        uint256 high = array.length;
         uint256 low = 0;
+        uint256 high = array.length;
 
         while (low < high) {
-            uint256 mid = (low & high) + (low ^ high) / 2;
+            uint256 mid = (low + high) / 2;
             if (array[mid].tokenId > tokenId) {
                 high = mid;
             } else {
@@ -75,11 +75,17 @@ contract DixelArt is Context, ERC721, ERC721Enumerable, Ownable, DixelSVGGenerat
             }
         }
 
-        if (low > 0 && array[low-1].tokenId == tokenId) {
+        if (low > array.length-1) {
             return array[low-1].color;
-        } else {
-            return array[low].color;
         }
+        if (low > 0 && array[low-1].tokenId >= tokenId) {
+            return array[low-1].color;
+        }
+        if (low > 0 && array[low].tokenId >= tokenId) {
+            return array[low-1].color;
+        }
+
+        return array[low].color;
     }
 
     function generateSVG(uint256 tokenId) external view returns (string memory) {

--- a/contracts/IPixelParams.sol
+++ b/contracts/IPixelParams.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.10;
+
+interface IPixelParams {
+
+    struct PixelParams {
+        uint8 x;
+        uint8 y;
+        uint24 color;
+    }
+}

--- a/contracts/mock/DixelMock.sol
+++ b/contracts/mock/DixelMock.sol
@@ -15,7 +15,7 @@ contract DixelMock is Dixel {
         return accRewardPerContribution;
     }
 
-    function updatePixelsOriginal(PixelParams[] calldata params, uint256 nextTokenId) external nonReentrant {
+    function updatePixelsOriginal(IPixelParams.PixelParams[] calldata params, uint256 nextTokenId) external nonReentrant {
         require(params.length > 0 && params.length <= CANVAS_SIZE * CANVAS_SIZE, "INVALID_PIXEL_PARAMS");
         require(nextTokenId == dixelArt.nextTokenId(), "NFT_EDITION_NUMBER_MISMATCHED");
 
@@ -50,12 +50,12 @@ contract DixelMock is Dixel {
         (uint96 reward, uint96 reserveForRefund) = _updatePlayerReward(player, totalPrice, updatedPixelCount);
 
         // Mint NFT to the user
-        dixelArt.mint(msgSender, getPixelColors(), updatedPixelCount, reserveForRefund);
+        dixelArt.mint(msgSender, params, updatedPixelCount, reserveForRefund);
 
         emit UpdatePixels(msgSender, updatedPixelCount, uint96(totalPrice), reward);
     }
 
-    function updatePixelsNoChecks(PixelParams[] calldata params, uint256 nextTokenId) external {
+    function updatePixelsNoChecks(IPixelParams.PixelParams[] calldata params, uint256 nextTokenId) external {
         require(params.length > 0 && params.length <= CANVAS_SIZE * CANVAS_SIZE, "INVALID_PIXEL_PARAMS");
         require(nextTokenId == dixelArt.nextTokenId(), "NFT_EDITION_NUMBER_MISMATCHED");
 
@@ -79,7 +79,7 @@ contract DixelMock is Dixel {
         (uint96 reward, uint96 reserveForRefund) = _updatePlayerReward(player, totalPrice, updatedPixelCount);
 
         // Mint NFT to the user
-        dixelArt.mint(msgSender, getPixelColors(), updatedPixelCount, reserveForRefund);
+        dixelArt.mint(msgSender, params, updatedPixelCount, reserveForRefund);
 
         emit UpdatePixels(msgSender, updatedPixelCount, uint96(totalPrice), reward);
     }


### PR DESCRIPTION
In your code, upon every updating of pixels, the whole image was being written to storage (`history`).

I have changed it so only the changes are being written incrementally to storage.

Then DixelArt's `getPixelsFor` rebuilds the image using the new `getPixelAt`, which uses binary search to search the pixel history.

This moves the cost to a view function which is practically free.

As a result, `updatePixels` now takes around 60-70% less gas.

Perhaps more testing is needed, but I think this ok, and the gas savings are massive.

Let me know if you have any questions or issues.

This is the gas consumption the tests now show:
```
····························|························|·············|·············|··············|···············|··············
|  Contract                 ·  Method                ·  Min        ·  Max        ·  Avg         ·  # calls      ·  usd (avg)  │
····························|························|·············|·············|··············|···············|··············
|  DixelMock                ·  updatePixels          ·     373116  ·     446184  ·      421279  ·          107  ·          -  │
····························|························|·············|·············|··············|···············|··············
|  DixelMock                ·  updatePixelsNoChecks  ·          -  ·          -  ·    13701023  ·            1  ·          -  │
····························|························|·············|·············|··············|···············|··············
|  DixelMock                ·  updatePixelsOriginal  ·          -  ·          -  ·    13987008  ·            1  ·          -  │
```